### PR TITLE
[TASK] Allow codeception/codeception 5.0.0 release along with dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "RC",
     "require": {
         "php": "^7.4 || ^8.0",
-        "codeception/codeception": "*@dev"
+        "codeception/codeception": "^5.0 || *@dev"
     },
     "conflict": {
         "codeception/codeception": "<4.0"


### PR DESCRIPTION
codeception/codeception has been relased. Add released version for
require package, so installation with released version is possible.

Used command:

```
composer req --no-update codeception/codeception:"^5.0 || *@dev"
```

Having a release afterwards would be nice.