### PR TITLE
Unset SHELL_VERBOSITY environment variable before execution of command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,14 @@ jobs:
     - name: Validate composer.json and composer.lock
       run: composer validate
 
+    - name: Install Codeception 4 on PHP 7.4
+      if: matrix.php == '7.4'
+      run: composer require codeception/codeception:"^4.2" -W --no-update
+
+    - name: Install Codeception 5 on PHP 8
+      if: matrix.php != '7.4'
+      run: composer require codeception/codeception:"^5.0" -W --no-update
+
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-interaction --no-suggest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [7.4, 8.0, 8.1, 8.2]
 
     steps:
     - name: Checkout code
@@ -27,4 +27,4 @@ jobs:
       run: composer install --prefer-dist --no-progress --no-interaction --no-suggest
 
     - name: Run test suite
-      run: php -l src/Codeception/Module/Cli.php
+      run: php vendor/bin/codecept run

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,0 +1,20 @@
+namespace: Tests
+support_namespace: Support
+suites:
+    cli:
+        path: .
+        actor: CliTester
+        modules:
+            enabled:
+                - Asserts
+                - Cli
+        step_decorators: ~
+
+settings:
+    shuffle: true
+    lint: true
+paths:
+    tests: tests
+    output: tests/_output
+    support: tests/Support
+    data: tests/Support/Data

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,9 @@
 {
     "name": "codeception/module-cli",
     "description": "Codeception module for testing basic shell commands and shell output",
-    "keywords": [ "codeception" ],
+    "keywords": [
+        "codeception"
+    ],
     "homepage": "https://codeception.com/",
     "type": "library",
     "license": "MIT",
@@ -13,7 +15,8 @@
     "minimum-stability": "RC",
     "require": {
         "php": "^7.4 || ^8.0",
-        "codeception/codeception": "*@dev"
+        "codeception/codeception": "*@dev",
+        "codeception/module-asserts": "*"
     },
     "conflict": {
         "codeception/codeception": "<4.0"

--- a/src/Codeception/Module/Cli.php
+++ b/src/Codeception/Module/Cli.php
@@ -45,6 +45,13 @@ class Cli extends Module
     public function runShellCommand(string $command, bool $failNonZero = true): void
     {
         $data = [];
+        /**
+         * \Symfony\Component\Console\Application::configureIO sets SHELL_VERBOSITY environment variable
+         * which may affect execution of shell command
+         */
+        if (\function_exists('putenv')) {
+            @putenv('SHELL_VERBOSITY');
+        }
         exec("{$command}", $data, $resultCode);
         $this->result = $resultCode;
         $this->output = implode("\n", $data);

--- a/tests/ShellVerbosityIsNotInheritedCest.php
+++ b/tests/ShellVerbosityIsNotInheritedCest.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace Tests\Cli;
+
+use Tests\Support\CliTester;
+
+class ShellVerbosityIsNotInheritedCest
+{
+    /**
+     * \Symfony\Component\Console\Application::configureIO sets SHELL_VERBOSITY environment variable
+     * which may affect execution of shell command
+     */
+    public function shellVerbosityIsNotInheritedFromCodeception(CliTester $I)
+    {
+        $I->runShellCommand('php ' . codecept_data_dir('check_verbosity.php'));
+        $I->seeInShellOutput('bool(false)');
+    }
+}

--- a/tests/ShellVerbosityIsNotInheritedCest.php
+++ b/tests/ShellVerbosityIsNotInheritedCest.php
@@ -7,10 +7,6 @@ use Tests\Support\CliTester;
 
 class ShellVerbosityIsNotInheritedCest
 {
-    /**
-     * \Symfony\Component\Console\Application::configureIO sets SHELL_VERBOSITY environment variable
-     * which may affect execution of shell command
-     */
     public function shellVerbosityIsNotInheritedFromCodeception(CliTester $I)
     {
         $I->runShellCommand('php ' . codecept_data_dir('check_verbosity.php'));

--- a/tests/Support/CliTester.php
+++ b/tests/Support/CliTester.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Support;
 
+require_once __DIR__ . '/_generated/CliTesterActions.php';
+
+if (trait_exists(\Tests\_generated\CliTesterActions::class, false)) {
+    class_alias(\Tests\_generated\CliTesterActions::class, \Tests\Support\_generated\CliTesterActions::class);
+}
+
 /**
  * Inherited Methods
  *
@@ -28,3 +34,5 @@ class CliTester extends \Codeception\Actor
      * Define custom actions here
      */
 }
+
+class_alias(CliTester::class, \Tests\CliTester::class);

--- a/tests/Support/CliTester.php
+++ b/tests/Support/CliTester.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause($vars = [])
+ *
+ * @SuppressWarnings(PHPMD)
+ */
+class CliTester extends \Codeception\Actor
+{
+    use _generated\CliTesterActions;
+
+    /**
+     * Define custom actions here
+     */
+}

--- a/tests/Support/Data/check_verbosity.php
+++ b/tests/Support/Data/check_verbosity.php
@@ -1,0 +1,3 @@
+<?php
+
+var_dump(getenv('SHELL_VERBOSITY'));

--- a/tests/Support/_generated/.gitignore
+++ b/tests/Support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/_output/.gitignore
+++ b/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
While testing Codeception, I noticed that some cli tests fail when Codeception is executed with `-v` flag.

For example RunSkippedCept:
```
Codeception$ ./codecept run cli RunSkippedCept
Codeception PHP Testing Framework v5.0.6 https://helpukrainewin.org

Cli Tests (1) -----------------------------------------------------------------------------------------------------------------------
✔ RunSkippedCept: Run skipped test (0.09s)
-------------------------------------------------------------------------------------------------------------------------------------
Time: 00:00.283, Memory: 8.00 MB

OK (1 test, 3 assertions)

Codeception$ ./codecept run cli RunSkippedCept -v
Codeception PHP Testing Framework v5.0.6 https://helpukrainewin.org

Cli Tests (1) -----------------------------------------------------------------------------------------------------------------------
Modules: Filesystem, Cli, CliHelper, CodeHelper, Asserts
-------------------------------------------------------------------------------------------------------------------------------------
✖ RunSkippedCept: Run skipped test (0.09s)
-------------------------------------------------------------------------------------------------------------------------------------
Time: 00:00.286, Memory: 8.00 MB

There was 1 failure:
1) RunSkippedCept: Run skipped test
 Test  tests/cli/RunSkippedCept.php
 Step  See in shell output "run with `-v` to get more info"
 Fail  Failed asserting that 'Codeception PHP Testing Framework v5.0.6 https://helpukrainewin.org\n
\n
Skipped Tests (1) -------------------------------------------------------------------------------------------------------------------\n
Modules: SkipHelper\n
-------------------------------------------------------------------------------------------------------------------------------------\n
S SkipMeCept: Skip it\n
-------------------------------------------------------------------------------------------------------------------------------------\n
Time: 00:00.019, Memory: 6.00 MB\n
\n
There was 1 skipped test:\n
1) SkipMeCept: Skip it\n
 Test  tests/skipped/SkipMeCept.php\n
OK, but incomplete, skipped, or useless tests!\n
Tests: 1, Assertions: 0, Skipped: 1.' contains "run with `-v` to get more info".

Scenario Steps:

 5. $I->seeInShellOutput("run with `-v` to get more info") at tests/cli/RunSkippedCept.php:9
 4. $I->seeInShellOutput("OK, but incomplete, skipped, or useless tests!") at tests/cli/RunSkippedCept.php:8
 3. $I->seeInShellOutput("S SkipMeCept: Skip it") at tests/cli/RunSkippedCept.php:7
 2. $I->executeCommand("run skipped SkipMeCept.php") at tests/cli/RunSkippedCept.php:6
 1. $I->amInPath("tests/data/sandbox") at tests/cli/RunSkippedCept.php:5
```

During investigation I discovered that `\Symfony\Component\Console\Application::configureIO` method sets `SHELL_VERBOSITY` variable which affects verbosity of the child process:
https://github.com/symfony/console/blob/3e294254f2191762c1d137aed4b94e966965e985/Application.php#L958

`\Symfony\Component\Console\Tester\ApplicationTester` unsets `SHELL_VERBOSITY` too, so it seems like a good approach to unset it in `Cli::runShellCommand`.