### PR TITLE
seeResultCodeIs(): Fixing order of arguments

### DIFF
--- a/src/Codeception/Module/Cli.php
+++ b/src/Codeception/Module/Cli.php
@@ -106,7 +106,7 @@ class Cli extends Module
      */
     public function seeResultCodeIs(int $code): void
     {
-        $this->assertEquals($this->result, $code, "result code is {$code}");
+        $this->assertEquals($code, $this->result, "result code is {$this->result}");
     }
 
     /**
@@ -119,6 +119,6 @@ class Cli extends Module
      */
     public function seeResultCodeIsNot(int $code): void
     {
-        $this->assertNotEquals($this->result, $code, "result code is {$code}");
+        $this->assertNotEquals($code, $this->result, "result code is {$this->result}");
     }
 }


### PR DESCRIPTION
When test code is `$I->seeResultCodeIs(0);`:
Before:
```
Step  See result code is 0
Fail  result code is 0
Failed asserting that 0 matches expected 4
```
After:
```
Step  See result code is 0
Fail  result code is 4
Failed asserting that 4 matches expected 0.
```